### PR TITLE
Add service workers for caching

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -87,6 +87,7 @@
       </symbol>
     </svg>
     <header>
+      <div class="alert-banner">Hmm, you appear to be offline. Please refresh the page for full functionality.</div>
       <svg class="logo" id="logo" width="463px" height="444px" viewBox="0 0 463 444" version="1.1" xmlns="http://www.w3.org/2000/svg">
         <g id="Circle" fill="#1C3764">
           <circle id="Blue" cx="222" cy="222" r="222"></circle>
@@ -130,7 +131,7 @@
 
     <footer>&copy;2016 Derrick Showers</footer>
 
-    <script src="scripts/main.js"></script>
+    <script src="main.js"></script>
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -18,6 +18,21 @@ function init() {
       $alertMessageEl.removeClass('visible');
     }, 5000);
   });
+
+  // Register a service worker
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.addEventListener('message', event => {
+      if (event.data && event.data.offline) {
+        $('body').addClass('offline');
+        $('button').prop('disabled', true);
+      }
+    });
+    navigator.serviceWorker.register('/sw.js').then(registration => {
+      console.log('ServiceWorker registration success: ', registration);
+    }).catch(function(err) {
+      console.log('ServiceWorker registration failed: ', err);
+    });
+  }
 }
 
 init();

--- a/app/scripts/sw.js
+++ b/app/scripts/sw.js
@@ -1,0 +1,39 @@
+/* globals caches: true, self: true */
+
+const CACHE_NAME = 'derrickshowers-v0.0.2';
+const urlsToCache = [
+  '/',
+  '/css/main.css',
+  '/main.js'
+];
+
+self.addEventListener('install', function(event) {
+  console.log('Service worker installed');
+  event.waitUntil(caches.open(CACHE_NAME).then(cache => {
+    return cache.addAll(urlsToCache);
+  }));
+});
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(caches.match(event.request).then(function(response) {
+    // Cache hit - return response
+    if (response) {
+      return response;
+    }
+
+    // IMPORTANT: Clone the request. A request is a stream and
+    // can only be consumed once. Since we are consuming this
+    // once by cache and once by the browser for fetch, we need
+    // to clone the response
+    let fetchRequest = event.request.clone();
+
+    return fetch(fetchRequest).catch(() => {
+      // Send postMessage that we're offline
+      self.clients.matchAll().then(function(clients) {
+        clients.forEach(function(client) {
+          client.postMessage({ offline: true });
+        });
+      });
+    });
+  }));
+});

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -8,6 +8,7 @@ $lightgray: #EAEDF2;
 $errorLightRed: #FFD0D0;
 $errorDarkRed: #B10000;
 $successGreen: #088A08;
+$white: #FFFFFF;
 
 // MIXINS/FUNCTIONS
 @mixin screen-reader-text() {
@@ -70,6 +71,16 @@ header {
 
 section {
   margin: 25px 0;
+}
+
+.alert-banner {
+  padding: 10px 0;
+  top: -10px;
+  position: relative;
+  background-color: $errorDarkRed;
+  color: $white;
+  font-size: .9rem;
+  display: none;
 }
 
 .social-list {
@@ -171,6 +182,13 @@ footer {
   text-align: center;
   padding: 20px 0 10px;
   font-size: .75rem;
+}
+
+// OFFLINE
+.offline {
+  .alert-banner {
+    display: block;
+  }
 }
 
 // MEDIA QUERIES

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,10 +62,10 @@ gulp.task('webpack', function(callback) {
 
 gulp.task('webpack-dev-server', function(callback) {
   var myConfig = Object.create(webpackConfig);
-  myConfig.entry.path.push('webpack-dev-server/client?http://localhost:8080');
+  myConfig.entry.main.push('webpack-dev-server/client?http://localhost:8080');
   new WebpackDevServer(webpack(myConfig), {
     contentBase: 'dist',
-    publicPath: '/' + myConfig.output.publicPath,
+    publicPath: '/',
     stats: {
 			colors: true
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "derrickshowersCom",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "index.html",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,12 @@ var path = require('path');
 
 module.exports = {
   entry: {
-    path: ['./app/scripts/main.js']
+    main: ['./app/scripts/main.js'],
+    sw: ['./app/scripts/sw.js']
   },
   output: {
-    path: path.join(__dirname, 'dist/scripts/'),
-    publicPath: 'scripts/',
-    filename: 'main.js'
+    path: path.join(__dirname, 'dist/'),
+    filename: '[name].js'
   },
   module: {
     loaders: [


### PR DESCRIPTION
After installing [Let's Encrypt!](https://letsencrypt.org/) on the server, service workers for offline access seemed like the next logical step. This isn't the final implementation, but it works pretty well.

What's left?
- [ ] Seem to be lots of errors in the console when serving files from the cache. What's up with that?
- [ ] Offline message shows until page is refreshed. It might be better to keep trying to fetch whatever failed and then get rid of the offline message.
